### PR TITLE
Add doctests across crate, add get/get_mut for tree types

### DIFF
--- a/benches/octree.rs
+++ b/benches/octree.rs
@@ -18,7 +18,7 @@ where
     type Sum = (usize, usize);
 
     fn gather(&self, m: M, _: &i32) -> Self::Sum {
-        if m.decode().0 > (M::one() << (M::dim_bits() - 1)) {
+        if m.decode().x > (M::one() << (M::dim_bits() - 1)) {
             (1, 0)
         } else {
             (0, 1)

--- a/src/morton.rs
+++ b/src/morton.rs
@@ -221,13 +221,13 @@ impl Morton for u64 {
         let [x, y, z]: [Self; 3] = dims.into();
         z.pdep(0x4924924924924924u64)
             | y.pdep(0x2492492492492492u64)
-            | x.pdep(0x9249249249249249u64)
+            | x.pdep(0x1249249249249249u64)
     }
 
     #[inline]
     fn decode(self) -> Vector3<Self> {
         let (x, y, z) = morton::bmi2::decode_3d(self);
-        Vector3::new(x, y, z)
+        Vector3::new(x & Self::used_bits(), y, z)
     }
 }
 

--- a/src/morton.rs
+++ b/src/morton.rs
@@ -215,6 +215,15 @@ pub trait Morton: PrimInt + FromPrimitive + ToPrimitive + Hash + std::fmt::Debug
 impl Morton for u64 {
     const BITS: usize = 64;
 
+    /// Encode a Vector3<u64> into a morton code.
+    ///
+    /// ```
+    /// use space::Morton;
+    /// use nalgebra::Vector3;
+    ///
+    /// let morton_code = Morton::encode(Vector3::<u64>::new(1, 2, 3));
+    /// assert_eq!(morton_code, 53);
+    /// ```
     #[inline]
     #[allow(clippy::unreadable_literal)]
     fn encode(dims: Vector3<Self>) -> Self {
@@ -224,6 +233,15 @@ impl Morton for u64 {
             | x.pdep(0x1249249249249249u64)
     }
 
+    /// Decode a u64 morton to its associated Vector3<u64>
+    ///
+    /// ```
+    /// use space::Morton;
+    /// use nalgebra::Vector3;
+    ///
+    /// let coordinates = Morton::decode(53);
+    /// assert_eq!(coordinates, Vector3::<u64>::new(1, 2, 3));
+    /// ```
     #[inline]
     fn decode(self) -> Vector3<Self> {
         let (x, y, z) = morton::bmi2::decode_3d(self);
@@ -234,20 +252,15 @@ impl Morton for u64 {
 impl Morton for u128 {
     const BITS: usize = 128;
 
-    #[inline]
-    #[allow(clippy::cast_lossless)]
-    fn decode(self) -> Vector3<Self> {
-        let low = self as u64;
-        let high = (self >> 63) as u64;
-        let (lowx, lowy, lowz) = morton::decode_3d(low);
-        let (highx, highy, highz) = morton::decode_3d(high);
-        Vector3::new(
-            (highx << 21 | lowx) as u128,
-            (highy << 21 | lowy) as u128,
-            (highz << 21 | lowz) as u128,
-        )
-    }
-
+    /// Encode a Vector3<u128> into a morton code.
+    ///
+    /// ```
+    /// use space::Morton;
+    /// use nalgebra::Vector3;
+    ///
+    /// let morton_code = Morton::encode(Vector3::<u128>::new(1, 2, 3));
+    /// assert_eq!(morton_code, 53);
+    /// ```
     #[inline]
     #[allow(clippy::cast_lossless)]
     fn encode(dims: Vector3<Self>) -> u128 {
@@ -261,6 +274,30 @@ impl Morton for u128 {
         let high = morton::encode_3d(highx as u64, highy as u64, highz as u64);
         let low = morton::encode_3d(lowx as u64, lowy as u64, lowz as u64);
         (high as u128) << 63 | low as u128
+    }
+
+
+    /// Decode a u128 morton to its associated Vector3<u128>
+    ///
+    /// ```
+    /// use space::Morton;
+    /// use nalgebra::Vector3;
+    ///
+    /// let coordinates = Morton::decode(53);
+    /// assert_eq!(coordinates, Vector3::<u128>::new(1, 2, 3));
+    /// ```
+    #[inline]
+    #[allow(clippy::cast_lossless)]
+    fn decode(self) -> Vector3<Self> {
+        let low = self as u64;
+        let high = (self >> 63) as u64;
+        let (lowx, lowy, lowz) = morton::decode_3d(low);
+        let (highx, highy, highz) = morton::decode_3d(high);
+        Vector3::new(
+            (highx << 21 | lowx) as u128,
+            (highy << 21 | lowy) as u128,
+            (highz << 21 | lowz) as u128,
+        )
     }
 }
 
@@ -284,28 +321,66 @@ pub struct MortonHash {
 
 #[allow(clippy::cast_lossless)]
 impl Hasher for MortonHash {
+
     #[inline]
     fn finish(&self) -> u64 {
         self.value
     }
 
+    ///```#[should_panic]
+    /// use std::hash::Hasher;
+    /// use space::MortonHash;
+    ///
+    /// let mut hash = MortonHash::default();
+    /// let val = [0; 1];
+    /// hash.write(&val);
+    ///```
     #[inline]
     fn write(&mut self, _: &[u8]) {
         panic!("Morton hash should only be used with a single 64 bit value");
     }
 
+    ///```#[should_panic]
+    /// use std::hash::Hasher;
+    /// use space::MortonHash;
+    ///
+    /// let mut hash = MortonHash::default();
+    /// hash.write_u8(1);
+    ///```
     fn write_u8(&mut self, _: u8) {
         panic!("Morton hash should only be used with a single 64 bit value");
     }
 
+    ///```#[should_panic]
+    /// use std::hash::Hasher;
+    /// use space::MortonHash;
+    ///
+    /// let mut hash = MortonHash::default();
+    /// hash.write_u16(1);
+    ///```
     fn write_u16(&mut self, _: u16) {
         panic!("Morton hash should only be used with a single 64 bit value");
     }
 
+    ///```#[should_panic]
+    /// use std::hash::Hasher;
+    /// use space::MortonHash;
+    ///
+    /// let mut hash = MortonHash::default();
+    /// hash.write_u32(1);
+    ///```
     fn write_u32(&mut self, _: u32) {
         panic!("Morton hash should only be used with a single 64 bit value");
     }
 
+    ///```
+    /// use std::hash::Hasher;
+    /// use space::MortonHash;
+    ///
+    /// let mut hash = MortonHash::default();
+    /// hash.write_u64(123);
+    /// assert_eq!(hash.finish(), 12638158613253308507);
+    ///```
     #[inline(always)]
     #[allow(clippy::unreadable_literal)]
     fn write_u64(&mut self, i: u64) {
@@ -316,6 +391,14 @@ impl Hasher for MortonHash {
             ((top ^ 14695981039346656037).wrapping_mul(1099511628211) & !bottom_mask) + bottom;
     }
 
+    ///```
+    /// use std::hash::Hasher;
+    /// use space::MortonHash;
+    ///
+    /// let mut hash = MortonHash::default();
+    /// hash.write_u128(123);
+    /// assert_eq!(hash.finish(), 12638158613253308507);
+    ///```
     #[inline(always)]
     #[allow(clippy::unreadable_literal)]
     fn write_u128(&mut self, i: u128) {
@@ -326,31 +409,90 @@ impl Hasher for MortonHash {
             + bottom) as u64;
     }
 
+    ///```#[should_panic]
+    /// use std::hash::Hasher;
+    /// use space::MortonHash;
+    ///
+    /// let mut hash = MortonHash::default();
+    /// hash.write_usize(123);
+    ///```
     fn write_usize(&mut self, _: usize) {
         panic!("Morton hash should only be used with a single 64 bit value");
     }
 
+    ///```#[should_panic]
+    /// use std::hash::Hasher;
+    /// use space::MortonHash;
+    ///
+    /// let mut hash = MortonHash::default();
+    /// hash.write_i8(123);
+    ///```
     fn write_i8(&mut self, _: i8) {
         panic!("Morton hash should only be used with a single 64 bit value");
     }
 
+    ///```#[should_panic]
+    /// use std::hash::Hasher;
+    /// use space::MortonHash;
+    ///
+    /// let mut hash = MortonHash::default();
+    /// hash.write_i16(123);
+    ///```
     fn write_i16(&mut self, _: i16) {
         panic!("Morton hash should only be used with a single 64 bit value");
     }
 
+    ///```#[should_panic]
+    /// use std::hash::Hasher;
+    /// use space::MortonHash;
+    ///
+    /// let mut hash = MortonHash::default();
+    /// hash.write_i32(123);
+    ///```
     fn write_i32(&mut self, _: i32) {
         panic!("Morton hash should only be used with a single 64 bit value");
     }
 
+    ///```#[should_panic]
+    /// use std::hash::Hasher;
+    /// use space::MortonHash;
+    ///
+    /// let mut hash = MortonHash::default();
+    /// hash.write_i64(123);
+    ///```
     fn write_i64(&mut self, _: i64) {
         panic!("Morton hash should only be used with a single 64 bit value");
     }
 
+    ///```#[should_panic]
+    /// use std::hash::Hasher;
+    /// use space::MortonHash;
+    ///
+    /// let mut hash = MortonHash::default();
+    /// hash.write_i128(123);
+    ///```
     fn write_i128(&mut self, _: i128) {
         panic!("Morton hash should only be used with a single 64 bit value");
     }
 
+    ///```#[should_panic]
+    /// use std::hash::Hasher;
+    /// use space::MortonHash;
+    ///
+    /// let mut hash = MortonHash::default();
+    /// hash.write_isize(123);
+    ///```
     fn write_isize(&mut self, _: isize) {
         panic!("Morton hash should only be used with a single 64 bit value");
     }
+}
+
+#[test]
+fn test_write() {
+    use std::hash::Hasher;
+    use crate::MortonHash;
+
+    let mut hash = MortonHash::default();
+    hash.write_u64(123);
+    println!("hash={}", hash.finish());
 }

--- a/src/morton/region.rs
+++ b/src/morton/region.rs
@@ -188,14 +188,12 @@ where
     fn into(self) -> Vector3<S> {
         let v = self.morton;
         let cut = M::dim_bits() - self.level;
-        let (x, y, z) = (v >> (3 * cut)).decode();
+        let point = (v >> (3 * cut)).decode();
         let scale = (S::one() + S::one()).powi(-(self.level as i32));
 
-        Vector3::new(
-            (S::from_u64(x.to_u64().unwrap()).unwrap() + S::from_f32(0.5).unwrap()) * scale,
-            (S::from_u64(y.to_u64().unwrap()).unwrap() + S::from_f32(0.5).unwrap()) * scale,
-            (S::from_u64(z.to_u64().unwrap()).unwrap() + S::from_f32(0.5).unwrap()) * scale,
-        )
+        point.map(|d| {
+            (S::from_u64(d.to_u64().unwrap()).unwrap() + S::from_f32(0.5).unwrap()) * scale
+        })
     }
 }
 

--- a/src/morton/wrapper.rs
+++ b/src/morton/wrapper.rs
@@ -43,15 +43,15 @@ where
 {
     #[inline]
     fn from(point: Vector3<S>) -> Self {
-        let point = point.map(|x| {
+        let point = point.map(|d| {
             M::from_u64(
-                (x * (S::one() + S::one()).powi(M::dim_bits() as i32))
+                (d * (S::one() + S::one()).powi(M::dim_bits() as i32))
                     .to_u64()
                     .unwrap(),
             )
             .unwrap()
         });
-        MortonWrapper(M::encode(point.x, point.y, point.z))
+        MortonWrapper(M::encode(point))
     }
 }
 
@@ -62,13 +62,11 @@ where
 {
     #[inline]
     fn into(self) -> Vector3<S> {
-        let (x, y, z) = self.0.decode();
+        let point = self.0.decode();
         let scale = (S::one() + S::one()).powi(-(M::dim_bits() as i32));
 
-        Vector3::new(
-            (S::from_u64(x.to_u64().unwrap()).unwrap() + S::from_f32(0.5).unwrap()) * scale,
-            (S::from_u64(y.to_u64().unwrap()).unwrap() + S::from_f32(0.5).unwrap()) * scale,
-            (S::from_u64(z.to_u64().unwrap()).unwrap() + S::from_f32(0.5).unwrap()) * scale,
-        )
+        point.map(|d| {
+            (S::from_u64(d.to_u64().unwrap()).unwrap() + S::from_f32(0.5).unwrap()) * scale
+        })
     }
 }

--- a/src/octree/linear.rs
+++ b/src/octree/linear.rs
@@ -1,6 +1,28 @@
 use crate::*;
 
 /// A linear hashed octree. This has constant time lookup for a given region or morton code.
+///
+/// ```
+/// use space::*;
+///
+/// let mut tree = LinearOctree::<String, u64>::new();
+///
+/// let region = space::LeveledRegion(0);
+/// let morton = region.discretize::<f32, u64>(nalgebra::Vector3::new(0.5, 0.5, 0.5)).unwrap();
+///
+/// // Insert a value into the tree
+/// tree.insert(morton, "test1".to_string() );
+///
+/// // Fetch a value at a specific coordinate
+/// let fetched_value = tree.get(morton);
+/// assert_eq!("test1", *fetched_value.unwrap());
+///
+/// // Fetch a value that doesnt exist
+/// let morton_empty = region.discretize::<f32, u64>(nalgebra::Vector3::new(0.1, 0.1, 0.1)).unwrap();
+/// let fetched_value = tree.get(morton_empty);
+/// assert!(fetched_value.is_none());
+///
+/// ```
 #[derive(Clone)]
 pub struct LinearOctree<T, M> {
     /// The leaves of the octree.
@@ -95,6 +117,11 @@ where
                 }
             }
         }
+    }
+
+    /// Fetches a value at a specific coordinate in the octree
+    pub fn get(&mut self, morton: M) -> Option<&T> {
+        self.leaves.get(&MortonWrapper(morton))
     }
 
     /// This gathers the octree in a tree fold by gathering leaves with `gatherer` and folding with `folder`.

--- a/src/octree/linear.rs
+++ b/src/octree/linear.rs
@@ -4,22 +4,21 @@ use crate::*;
 ///
 /// ```
 /// use space::*;
+/// use nalgebra::Vector3;
 ///
 /// let mut tree = LinearOctree::<String, u64>::new();
-///
-/// let region = space::LeveledRegion(0);
-/// let morton = region.discretize::<f32, u64>(nalgebra::Vector3::new(0.5, 0.5, 0.5)).unwrap();
+/// let coord = Vector3::<u64>::new(1, 2, 3);
 ///
 /// // Insert a value into the tree
-/// tree.insert(morton, "test1".to_string() );
+/// tree.insert(Morton::encode(coord), "test1".to_string() );
 ///
 /// // Fetch a value at a specific coordinate
-/// let fetched_value = tree.get(morton);
+/// let fetched_value = tree.get(Morton::encode(coord));
 /// assert_eq!("test1", *fetched_value.unwrap());
 ///
 /// // Fetch a value that doesnt exist
-/// let morton_empty = region.discretize::<f32, u64>(nalgebra::Vector3::new(0.1, 0.1, 0.1)).unwrap();
-/// let fetched_value = tree.get(morton_empty);
+/// let coord_empty = Vector3::<u64>::new(4, 5, 6);
+/// let fetched_value = tree.get(Morton::encode(coord_empty));
 /// assert!(fetched_value.is_none());
 ///
 /// ```
@@ -119,9 +118,14 @@ where
         }
     }
 
-    /// Fetches a value at a specific coordinate in the octree
-    pub fn get(&mut self, morton: M) -> Option<&T> {
+    /// Fetches an immutable reference to the value of a specific coordinate in the octree
+    pub fn get(&self, morton: M) -> Option<&T> {
         self.leaves.get(&MortonWrapper(morton))
+    }
+
+    /// Fetches a mutable reference to the value of a specific coordinate in the octree
+    pub fn get_mut(&mut self, morton: M) -> Option<&mut T> {
+        self.leaves.get_mut(&MortonWrapper(morton))
     }
 
     /// This gathers the octree in a tree fold by gathering leaves with `gatherer` and folding with `folder`.

--- a/src/octree/linear.rs
+++ b/src/octree/linear.rs
@@ -3,7 +3,7 @@ use crate::*;
 /// A linear hashed octree. This has constant time lookup for a given region or morton code.
 ///
 /// ```
-/// use space::*;
+/// use space::{LinearOctree, Morton};
 /// use nalgebra::Vector3;
 ///
 /// let mut tree = LinearOctree::<String, u64>::new();
@@ -35,6 +35,13 @@ impl<T, M> Default for LinearOctree<T, M>
 where
     M: Morton,
 {
+    /// Create a default, empty linear Octree
+    ///
+    /// ```
+    /// use space::LinearOctree;
+    /// let mut tree = LinearOctree::<String, u64>::new();
+    ///
+    /// ```
     fn default() -> Self {
         let mut internals = MortonRegionMap::default();
         internals.insert(MortonRegion::default(), M::null());
@@ -49,7 +56,13 @@ impl<T, M> LinearOctree<T, M>
 where
     M: Morton,
 {
-    /// Create an empty linear octree.
+    /// Create an empty octree. Calls Default impl.
+    ///
+    /// ```
+    /// use space::LinearOctree;
+    /// let mut tree = LinearOctree::<String, u64>::new();
+    ///
+    /// ```
     pub fn new() -> Self {
         Default::default()
     }
@@ -57,6 +70,15 @@ where
     /// Inserts the item into the octree.
     ///
     /// If another element occupied the exact same morton, it will be evicted and replaced.
+    ///
+    /// ```
+    /// use space::{LinearOctree, Morton};
+    /// use nalgebra::Vector3;
+    ///
+    /// let mut tree = LinearOctree::<String, u64>::new();
+    /// tree.insert(Morton::encode(Vector3::new(1, 2, 3)), "test1".to_string() );
+    ///
+    /// ```
     pub fn insert(&mut self, morton: M, item: T) {
         use std::collections::hash_map::Entry::*;
         // First we must insert the node into the leaves.
@@ -119,6 +141,16 @@ where
     }
 
     /// Fetches an immutable reference to the value of a specific coordinate in the octree
+    ///
+    /// ```
+    /// use space::{LinearOctree, Morton};
+    /// use nalgebra::Vector3;
+    ///
+    /// let mut tree = LinearOctree::<String, u64>::new();
+    ///
+    /// let fetched_value = tree.get(Morton::encode(Vector3::<u64>::new(1, 2, 3)));
+    /// assert!(fetched_value.is_none());
+    /// ```
     pub fn get(&self, morton: M) -> Option<&T> {
         self.leaves.get(&MortonWrapper(morton))
     }

--- a/src/octree/pointer.rs
+++ b/src/octree/pointer.rs
@@ -28,6 +28,12 @@ pub struct PointerOctree<T, M> {
 }
 
 impl<T, M> Default for PointerOctree<T, M> {
+    /// Create an empty octree.
+    /// ```
+    /// use space::PointerOctree;
+    /// let mut tree = PointerOctree::<String, u64>::default();
+    ///
+    /// ```
     fn default() -> Self {
         PointerOctree {
             tree: Internal::default(),
@@ -40,12 +46,27 @@ impl<T, M> PointerOctree<T, M>
 where
     M: Morton,
 {
-    /// Creates a new empty octree.
+    /// Create an empty octree. Calls Default impl.
+    ///
+    /// ```
+    /// use space::PointerOctree;
+    /// let mut tree = PointerOctree::<String, u64>::new();
+    ///
+    /// ```
     pub fn new() -> Self {
         Self::default()
     }
 
     /// Fetches an immutable reference to the value of a specific coordinate in the octree
+    /// ```
+    /// use space::{PointerOctree, Morton};
+    /// use nalgebra::Vector3;
+    ///
+    /// let mut tree = PointerOctree::<String, u64>::new();
+    ///
+    /// let fetched_value = tree.get(Morton::encode(Vector3::<u64>::new(1, 2, 3)));
+    /// assert!(fetched_value.is_none());
+    /// ```
     pub fn get(&self, morton: M) -> Option<&T> {
         // Traverse the tree down to the node we need to operate on.
         let (tree_part, _) = (0..M::dim_bits())
@@ -85,6 +106,16 @@ where
     }
 
     /// Fetches a mututable reference to the value of a specific coordinate in the octree
+    ///
+    /// ```
+    /// use space::{PointerOctree, Morton};
+    /// use nalgebra::Vector3;
+    ///
+    /// let mut tree = PointerOctree::<String, u64>::new();
+    ///
+    /// let fetched_value = tree.get(Morton::encode(Vector3::<u64>::new(1, 2, 3)));
+    /// assert!(fetched_value.is_none());
+    /// ```
     pub fn get_mut(&mut self, morton: M) -> Option<&T> {
         // Traverse the tree down to the node we need to operate on.
         let (tree_part, _) = (0..M::dim_bits())
@@ -124,6 +155,15 @@ where
     }
 
     /// Insert an item with a point and replace the existing item if they would both occupy the same space.
+    ///
+    /// ```
+    /// use space::{PointerOctree, Morton};
+    /// use nalgebra::Vector3;
+    ///
+    /// let mut tree = PointerOctree::<String, u64>::new();
+    /// tree.insert(Morton::encode(Vector3::new(1, 2, 3)), "test1".to_string() );
+    ///
+    /// ```
     pub fn insert(&mut self, morton: M, item: T) {
         // Traverse the tree down to the node we need to operate on.
         let (tree_part, level) = (0..M::dim_bits())


### PR DESCRIPTION
As a WIP while implementing a crate using the (obviously unfinished) octree implementation here, adding doctests and some functionality was the easiest way to get started learning it. 

The doctests aren't complete across the crate yet, as I'm currently implementing LinearOctree features for my use case as well. I'll keep filling this PR as I move along. 